### PR TITLE
[java-based-impl] Add paimon-python-java-bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 !.idea/vcs.xml
+target
+dependency-reduced-pom.xml

--- a/java-based-implementation/paimon-python-java-bridge/copyright.txt
+++ b/java-based-implementation/paimon-python-java-bridge/copyright.txt
@@ -1,0 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+

--- a/java-based-implementation/paimon-python-java-bridge/pom.xml
+++ b/java-based-implementation/paimon-python-java-bridge/pom.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.paimon</groupId>
+    <artifactId>paimon-python-java-bridge</artifactId>
+    <version>0.9-SNAPSHOT</version>
+    <name>Paimon : Python-Java Bridge</name>
+
+    <packaging>jar</packaging>
+
+    <properties>
+        <paimon.version>0.9-SNAPSHOT</paimon.version>
+        <flink.shaded.hadoop.version>2.8.3-10.0</flink.shaded.hadoop.version>
+        <py4j.version>0.10.9.7</py4j.version>
+        <slf4j.version>1.7.32</slf4j.version>
+        <spotless.version>2.13.0</spotless.version>
+    </properties>
+
+    <dependencies>
+
+        <!-- Java dependencies -->
+
+        <dependency>
+            <groupId>org.apache.paimon</groupId>
+            <artifactId>paimon-bundle</artifactId>
+            <version>${paimon.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-shaded-hadoop-2-uber</artifactId>
+            <version>${flink.shaded.hadoop.version}</version>
+        </dependency>
+
+        <!-- Python API dependencies -->
+
+        <dependency>
+            <groupId>net.sf.py4j</groupId>
+            <artifactId>py4j</artifactId>
+            <version>${py4j.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.version}</version>
+                <configuration>
+                    <java>
+                        <googleJavaFormat>
+                            <version>1.7</version>
+                            <style>AOSP</style>
+                        </googleJavaFormat>
+
+                        <!-- \# refers to the static imports -->
+                        <importOrder>
+                            <order>org.apache.paimon,org.apache.paimon.shade,,javax,java,scala,\#</order>
+                        </importOrder>
+
+                        <licenseHeader>
+                            <!-- replace it with ${project.rootDirectory} after maven 4.0.0, see MNG-7038 -->
+                            <file>${maven.multiModuleProjectDirectory}/copyright.txt</file>
+                            <delimiter>${spotless.delimiter}</delimiter>
+                        </licenseHeader>
+                    </java>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>spotless-check</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-paimon</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes combine.children="append">
+                                    <include>org.apache.paimon:paimon-bundle</include>
+                                    <include>org.slf4j:slf4j-api</include>
+                                    <include>org.apache.flink:flink-shaded-hadoop-2-uber</include>
+                                    <include>net.sf.py4j:py4j</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/java-based-implementation/paimon-python-java-bridge/src/main/java/org/apache/paimon/python/FileLock.java
+++ b/java-based-implementation/paimon-python-java-bridge/src/main/java/org/apache/paimon/python/FileLock.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.python;
+
+import org.apache.paimon.utils.Preconditions;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/** A file lock used for avoiding race condition among multiple threads/processes. */
+public class FileLock {
+    private static final String TEMP_DIR = System.getProperty("java.io.tmpdir");
+    private final File file;
+    private FileOutputStream outputStream;
+    private java.nio.channels.FileLock lock;
+
+    /**
+     * Initialize a FileLock using a file located at fullPath.
+     *
+     * @param fullPath The path of the locking file
+     */
+    public FileLock(String fullPath) {
+        Preconditions.checkNotNull(fullPath, "fullPath should not be null");
+        Path path = Paths.get(fullPath);
+        String normalizedFileName = normalizeFileName(path.getFileName().toString());
+        if (normalizedFileName.isEmpty()) {
+            throw new IllegalArgumentException("There are no legal characters in the file name");
+        }
+        this.file =
+                path.getParent() == null
+                        ? new File(TEMP_DIR, normalizedFileName)
+                        : new File(path.getParent().toString(), normalizedFileName);
+    }
+
+    /**
+     * Initialize a FileLock using a file located at parentDir/fileName.
+     *
+     * @param parentDir The parent dir of the locking file
+     * @param fileName The name of the locking file
+     */
+    public FileLock(String parentDir, String fileName) {
+        Preconditions.checkNotNull(parentDir, "parentDir should not be null");
+        Preconditions.checkNotNull(fileName, "fileName should not be null");
+        this.file = new File(parentDir, normalizeFileName(fileName));
+    }
+
+    /**
+     * Initialize a FileLock using a file located inside temp folder.
+     *
+     * @param fileName The name of the locking file
+     * @return The initialized FileLock
+     */
+    public static FileLock inTempFolder(String fileName) {
+        return new FileLock(TEMP_DIR, fileName);
+    }
+
+    /**
+     * Check whether the locking file exists in the file system. Create it if it does not exist.
+     * Then create a FileOutputStream for it.
+     *
+     * @throws IOException If the file path is invalid or the parent dir does not exist
+     */
+    private void init() throws IOException {
+        if (!this.file.exists()) {
+            this.file.createNewFile();
+        }
+        outputStream = new FileOutputStream(this.file);
+    }
+
+    /**
+     * Try to acquire a lock on the locking file. This method immediately returns whenever the lock
+     * is acquired or not.
+     *
+     * @return True if successfully acquired the lock
+     * @throws IOException If the file path is invalid
+     */
+    public boolean tryLock() throws IOException {
+        if (outputStream == null) {
+            init();
+        }
+        try {
+            lock = outputStream.getChannel().tryLock();
+        } catch (Exception e) {
+            return false;
+        }
+
+        return lock != null;
+    }
+
+    /**
+     * Release the file lock.
+     *
+     * @throws IOException If the FileChannel is closed
+     */
+    public void unlock() throws IOException {
+        if (lock != null && lock.channel().isOpen()) {
+            lock.release();
+        }
+    }
+
+    /**
+     * Release the file lock, close the fileChannel and FileOutputStream then try deleting the
+     * locking file if other file lock does not need it, which means the lock will not be used
+     * anymore.
+     *
+     * @throws IOException If an I/O error occurs
+     */
+    public void unlockAndDestroy() throws IOException {
+        try {
+            unlock();
+            if (lock != null) {
+                lock.channel().close();
+                lock = null;
+            }
+            if (outputStream != null) {
+                outputStream.close();
+                outputStream = null;
+            }
+
+        } finally {
+            this.file.delete();
+        }
+    }
+
+    /**
+     * Check whether a FileLock is actually holding the lock.
+     *
+     * @return True if it is actually holding the lock
+     */
+    public boolean isValid() {
+        if (lock != null) {
+            return lock.isValid();
+        }
+        return false;
+    }
+
+    /**
+     * Normalize the file name, which only allows slash, backslash, digits and letters.
+     *
+     * @param fileName Original file name
+     * @return File name with illegal characters stripped
+     */
+    private static String normalizeFileName(String fileName) {
+        return fileName.replaceAll("[^\\w/\\\\]", "");
+    }
+}

--- a/java-based-implementation/paimon-python-java-bridge/src/main/java/org/apache/paimon/python/NetUtils.java
+++ b/java-based-implementation/paimon-python-java-bridge/src/main/java/org/apache/paimon/python/NetUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.python;
+
+import org.apache.paimon.utils.Preconditions;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+/** Utility for various network related tasks (such as finding free ports). */
+public class NetUtils {
+
+    /**
+     * Find a non-occupied port.
+     *
+     * @return A non-occupied port.
+     */
+    public static Port getAvailablePort() {
+        for (int i = 0; i < 50; i++) {
+            try (ServerSocket serverSocket = new ServerSocket(0)) {
+                int port = serverSocket.getLocalPort();
+                if (port != 0) {
+                    FileLock fileLock = new FileLock(NetUtils.class.getName() + port);
+                    if (fileLock.tryLock()) {
+                        return new Port(port, fileLock);
+                    } else {
+                        fileLock.unlockAndDestroy();
+                    }
+                }
+            } catch (IOException ignored) {
+            }
+        }
+
+        throw new RuntimeException("Could not find a free permitted port on the machine.");
+    }
+
+    /**
+     * Port wrapper class which holds a {@link FileLock} until it releases. Used to avoid race
+     * condition among multiple threads/processes.
+     */
+    public static class Port implements AutoCloseable {
+        private final int port;
+        private final FileLock fileLock;
+
+        public Port(int port, FileLock fileLock) throws IOException {
+            Preconditions.checkNotNull(fileLock, "FileLock should not be null");
+            Preconditions.checkState(fileLock.isValid(), "FileLock should be locked");
+            this.port = port;
+            this.fileLock = fileLock;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        @Override
+        public void close() throws Exception {
+            fileLock.unlockAndDestroy();
+        }
+    }
+}

--- a/java-based-implementation/paimon-python-java-bridge/src/main/java/org/apache/paimon/python/PythonEnvUtils.java
+++ b/java-based-implementation/paimon-python-java-bridge/src/main/java/org/apache/paimon/python/PythonEnvUtils.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.python;
+
+import org.apache.paimon.utils.Preconditions;
+
+import py4j.CallbackClient;
+import py4j.Gateway;
+import py4j.GatewayServer;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+/** The util class help to prepare Python env and run the python process. */
+final class PythonEnvUtils {
+
+    static final long CHECK_INTERVAL = 100;
+
+    static final long TIMEOUT_MILLIS = 10000;
+
+    /**
+     * Creates a GatewayServer run in a daemon thread.
+     *
+     * @return The created GatewayServer
+     */
+    static GatewayServer startGatewayServer() throws ExecutionException, InterruptedException {
+        CompletableFuture<GatewayServer> gatewayServerFuture = new CompletableFuture<>();
+        Thread thread =
+                new Thread(
+                        () -> {
+                            try (NetUtils.Port port = NetUtils.getAvailablePort()) {
+                                int freePort = port.getPort();
+                                GatewayServer server =
+                                        new GatewayServer.GatewayServerBuilder()
+                                                .gateway(
+                                                        new Gateway(
+                                                                new ConcurrentHashMap<
+                                                                        String, Object>(),
+                                                                new CallbackClient(freePort)))
+                                                .javaPort(0)
+                                                .build();
+                                resetCallbackClientExecutorService(server);
+                                gatewayServerFuture.complete(server);
+                                server.start(true);
+                            } catch (Throwable e) {
+                                gatewayServerFuture.completeExceptionally(e);
+                            }
+                        });
+        thread.setName("py4j-gateway");
+        thread.setDaemon(true);
+        thread.start();
+        thread.join();
+        return gatewayServerFuture.get();
+    }
+
+    /**
+     * Reset a daemon thread to the callback client thread pool so that the callback server can be
+     * terminated when gate way server is shutting down. We need to shut down the none-daemon thread
+     * firstly, then set a new thread created in a daemon thread to the ExecutorService.
+     *
+     * @param gatewayServer the gateway which creates the callback server.
+     */
+    private static void resetCallbackClientExecutorService(GatewayServer gatewayServer)
+            throws NoSuchFieldException, IllegalAccessException, NoSuchMethodException,
+                    InvocationTargetException {
+        CallbackClient callbackClient = (CallbackClient) gatewayServer.getCallbackClient();
+        // The Java API of py4j does not provide approach to set "daemonize_connections" parameter.
+        // Use reflect to daemonize the connection thread.
+        Field executor = CallbackClient.class.getDeclaredField("executor");
+        executor.setAccessible(true);
+        ((ScheduledExecutorService) executor.get(callbackClient)).shutdown();
+        executor.set(callbackClient, Executors.newScheduledThreadPool(1, Thread::new));
+        Method setupCleaner = CallbackClient.class.getDeclaredMethod("setupCleaner");
+        setupCleaner.setAccessible(true);
+        setupCleaner.invoke(callbackClient);
+    }
+
+    /**
+     * Reset the callback client of gatewayServer with the given callbackListeningAddress and
+     * callbackListeningPort after the callback server started.
+     *
+     * @param callbackServerListeningAddress the listening address of the callback server.
+     * @param callbackServerListeningPort the listening port of the callback server.
+     */
+    public static void resetCallbackClient(
+            GatewayServer gatewayServer,
+            String callbackServerListeningAddress,
+            int callbackServerListeningPort)
+            throws UnknownHostException, InvocationTargetException, NoSuchMethodException,
+                    IllegalAccessException, NoSuchFieldException {
+
+        gatewayServer.resetCallbackClient(
+                InetAddress.getByName(callbackServerListeningAddress), callbackServerListeningPort);
+        resetCallbackClientExecutorService(gatewayServer);
+    }
+
+    /**
+     * Py4J both supports Java to Python RPC and Python to Java RPC. The GatewayServer object is the
+     * entry point of Java to Python RPC. Since the Py4j Python client will only be launched only
+     * once, the GatewayServer object needs to be reused.
+     */
+    private static GatewayServer gatewayServer = null;
+
+    static void setGatewayServer(GatewayServer gatewayServer) {
+        Preconditions.checkArgument(gatewayServer == null || PythonEnvUtils.gatewayServer == null);
+        PythonEnvUtils.gatewayServer = gatewayServer;
+    }
+}

--- a/java-based-implementation/paimon-python-java-bridge/src/main/java/org/apache/paimon/python/PythonGatewayServer.java
+++ b/java-based-implementation/paimon-python-java-bridge/src/main/java/org/apache/paimon/python/PythonGatewayServer.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.paimon.python;
+
+import py4j.GatewayServer;
+import py4j.Py4JPythonClient;
+
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.apache.paimon.python.PythonEnvUtils.CHECK_INTERVAL;
+import static org.apache.paimon.python.PythonEnvUtils.TIMEOUT_MILLIS;
+
+/** The Py4j Gateway Server provides RPC service for user's python process. */
+public class PythonGatewayServer {
+
+    /**
+     * Main method to start a local GatewayServer on an ephemeral port. It tells python side via a
+     * file.
+     *
+     * <p>See: py4j.GatewayServer.main()
+     */
+    public static void main(String[] args)
+            throws IOException, ExecutionException, InterruptedException, ClassNotFoundException {
+        GatewayServer gatewayServer = PythonEnvUtils.startGatewayServer();
+        PythonEnvUtils.setGatewayServer(gatewayServer);
+
+        int boundPort = gatewayServer.getListeningPort();
+        Py4JPythonClient callbackClient = gatewayServer.getCallbackClient();
+        int callbackPort = callbackClient.getPort();
+        if (boundPort == -1) {
+            System.out.println("GatewayServer failed to bind; exiting");
+            System.exit(1);
+        }
+
+        // Tells python side the port of our java rpc server
+        String handshakeFilePath = System.getenv("_PYPAIMON_CONN_INFO_PATH");
+        File handshakeFile = new File(handshakeFilePath);
+        File tmpPath =
+                Files.createTempFile(handshakeFile.getParentFile().toPath(), "connection", ".info")
+                        .toFile();
+        FileOutputStream fileOutputStream = new FileOutputStream(tmpPath);
+        DataOutputStream stream = new DataOutputStream(fileOutputStream);
+        stream.writeInt(boundPort);
+        stream.writeInt(callbackPort);
+        stream.close();
+        fileOutputStream.close();
+
+        if (!tmpPath.renameTo(handshakeFile)) {
+            System.out.println(
+                    "Unable to write connection information to handshake file: "
+                            + handshakeFilePath
+                            + ", now exit...");
+            System.exit(1);
+        }
+
+        try {
+            // This ensures that the server dies if its parent program dies.
+            Map<String, Object> entryPoint =
+                    (Map<String, Object>) gatewayServer.getGateway().getEntryPoint();
+
+            for (int i = 0; i < TIMEOUT_MILLIS / CHECK_INTERVAL; i++) {
+                if (entryPoint.containsKey("Watchdog")) {
+                    break;
+                }
+                Thread.sleep(CHECK_INTERVAL);
+            }
+            if (!entryPoint.containsKey("Watchdog")) {
+                System.out.println("Unable to get the Python watchdog object, now exit.");
+                System.exit(1);
+            }
+            Watchdog watchdog = (Watchdog) entryPoint.get("Watchdog");
+            while (watchdog.ping()) {
+                Thread.sleep(CHECK_INTERVAL);
+            }
+            gatewayServer.shutdown();
+            System.exit(0);
+        } finally {
+            System.exit(1);
+        }
+    }
+
+    /** A simple watch dog interface. */
+    public interface Watchdog {
+        boolean ping() throws InterruptedException;
+    }
+
+    /**
+     * This watchdog object is provided to Python side to check whether its parent process is alive.
+     */
+    public static Watchdog watchdog =
+            () -> {
+                Thread.sleep(10000);
+                return true;
+            };
+}

--- a/java-based-implementation/paimon-python-java-bridge/tools/maven/checkstyle.xml
+++ b/java-based-implementation/paimon-python-java-bridge/tools/maven/checkstyle.xml
@@ -1,0 +1,586 @@
+<?xml version="1.0"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<!DOCTYPE module PUBLIC
+	"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+	"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!--
+This is a checkstyle configuration file. For descriptions of
+what the following rules do, please see the checkstyle configuration
+page at http://checkstyle.sourceforge.net/config.html.
+
+This file is based on the checkstyle file of Apache Beam.
+-->
+
+<module name="Checker">
+
+	<module name="NewlineAtEndOfFile">
+		<!-- windows can use \r\n vs \n, so enforce the most used one ie UNIx style -->
+		<property name="lineSeparator" value="lf"/>
+	</module>
+
+	<module name="RegexpSingleline">
+		<!-- Checks that TODOs don't have stuff in parenthesis, e.g., username. -->
+		<property name="format" value="((//.*)|(\*.*))TODO\("/>
+		<property name="message" value="TODO comments must not include usernames."/>
+		<property name="severity" value="error"/>
+	</module>
+
+	<module name="RegexpSingleline">
+		<property name="format" value="\s+$"/>
+		<property name="message" value="Trailing whitespace"/>
+		<property name="severity" value="error"/>
+	</module>
+
+	<module name="RegexpSingleline">
+		<property name="format" value="Throwables.propagate\("/>
+		<property name="message" value="Throwables.propagate is deprecated"/>
+		<property name="severity" value="error"/>
+	</module>
+
+	<!-- Prevent *Tests.java as tools may not pick them up -->
+	<!--<module name="RegexpOnFilename">-->
+	<!--<property name="fileNamePattern" value=".*Tests\.java$" />-->
+	<!--</module>-->
+
+	<module name="SuppressionFilter">
+		<property name="file" value="${checkstyle.suppressions.file}" default="suppressions.xml"/>
+	</module>
+
+	<!-- Check that every module has a package-info.java -->
+	<!--<module name="JavadocPackage"/>-->
+
+	<!--
+
+	FLINK CUSTOM CHECKS
+
+	-->
+
+	<module name="FileLength">
+		<property name="max" value="3000"/>
+	</module>
+
+	<!-- All Java AST specific tests live under TreeWalker module. -->
+	<module name="TreeWalker">
+
+		<!-- Allow use of comment to suppress javadocstyle -->
+		<module name="SuppressionCommentFilter">
+			<property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
+			<property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
+			<property name="checkFormat" value="$1"/>
+		</module>
+
+		<!--
+
+		FLINK CUSTOM CHECKS
+
+		-->
+
+		<!-- Prohibit T.getT() methods for standard boxed types -->
+		<module name="Regexp">
+			<property name="format" value="Boolean\.getBoolean"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message" value="Use System.getProperties() to get system properties."/>
+		</module>
+
+		<module name="Regexp">
+			<property name="format" value="Integer\.getInteger"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message" value="Use System.getProperties() to get system properties."/>
+		</module>
+
+		<module name="Regexp">
+			<property name="format" value="Long\.getLong"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message" value="Use System.getProperties() to get system properties."/>
+		</module>
+
+		<!--
+
+		IllegalImport cannot blacklist classes so we have to fall back to Regexp.
+
+		-->
+
+		<!-- forbid use of org.jetbrains.annotations.Nullable validate -->
+		<module name="Regexp">
+			<property name="format" value="org\.jetbrains\.annotations\.Nullable"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use javax.annotation.Nullable instead of org.jetbrains.annotations.Nullable."/>
+		</module>
+		<!-- forbid use of commons lang validate -->
+		<module name="Regexp">
+			<property name="format" value="org\.apache\.commons\.lang3\.Validate"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use Guava Checks instead of Commons Validate. Please refer to the coding guidelines."/>
+		</module>
+		<!-- forbid the use of google.common.base.Preconditions -->
+		<module name="Regexp">
+			<property name="format" value="import com\.google\.common\.base\.Preconditions"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use Flink's Preconditions instead of Guava's Preconditions"/>
+		</module>
+		<module name="Regexp">
+			<property name="format" value="org\.apache\.hadoop\.shaded"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+				value="Use Paimon's shade instead of hadoop's shade"/>
+		</module>
+		<!-- forbid the use of com.google.common.annotations.VisibleForTesting -->
+		<module name="Regexp">
+			<property name="format"
+					  value="import com\.google\.common\.annotations\.VisibleForTesting"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use Flink's VisibleForTesting instead of Guava's VisibleForTesting"/>
+		</module>
+		<module name="Regexp">
+			<property name="format" value="import static com\.google\.common\.base\.Preconditions"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use Flink's Preconditions instead of Guava's Preconditions"/>
+		</module>
+		<!-- forbid the use of org.apache.commons.lang.SerializationUtils -->
+		<module name="Regexp">
+			<property name="format" value="org\.apache\.commons\.lang\.SerializationUtils"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use Flink's InstantiationUtil instead of common's SerializationUtils"/>
+		</module>
+		<module name="Regexp">
+			<property name="format" value="org\.apache\.commons\.lang3\.SerializationUtils"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use Flink's InstantiationUtil instead of common's SerializationUtils"/>
+		</module>
+		<module name="Regexp">
+			<property name="format" value="org\.apache\.commons\.lang\."/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message" value="Use commons-lang3 instead of commons-lang."/>
+		</module>
+		<module name="Regexp">
+			<property name="format" value="org\.codehaus\.jettison"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message" value="Use com.fasterxml.jackson instead of jettison."/>
+		</module>
+		<!-- forbid the use of flink.shaded.guava31.com.google.common -->
+		<module name="Regexp">
+			<property name="format" value="import static org\.apache\.flink\.shaded\.guava31\.com\.google\.common\.base\.Preconditions"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use Paimon's Preconditions instead of Guava's Preconditions"/>
+		</module>
+
+		<!-- Enforce Java-style array declarations -->
+		<module name="ArrayTypeStyle"/>
+
+		<module name="TodoComment">
+			<!-- Checks that disallowed strings are not used in comments.  -->
+			<property name="format" value="(FIXME)|(XXX)|(@author)"/>
+		</module>
+
+		<!--
+
+		IMPORT CHECKS
+
+		-->
+
+		<module name="RedundantImport">
+			<!-- Checks for redundant import statements. -->
+			<property name="severity" value="error"/>
+			<message key="import.redundancy"
+					 value="Redundant import {0}."/>
+		</module>
+
+		<module name="ImportOrder">
+			<!-- Checks for out of order import statements. -->
+			<property name="severity" value="error"/>
+			<property name="groups"
+					  value="org.apache.paimon,org.apache.paimon.shade,*,javax,java,scala"/>
+			<property name="separated" value="true"/>
+			<property name="sortStaticImportsAlphabetically" value="true"/>
+			<property name="option" value="bottom"/>
+			<property name="tokens" value="STATIC_IMPORT, IMPORT"/>
+			<message key="import.ordering"
+					 value="Import {0} appears after other imports that it should precede"/>
+		</module>
+
+		<module name="AvoidStarImport">
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="IllegalImport">
+			<property name="illegalPkgs"
+					  value="autovalue.shaded, avro.shaded, com.google.api.client.repackaged, com.google.appengine.repackaged"/>
+		</module>
+		<module name="IllegalImport">
+			<property name="illegalPkgs" value="org.codehaus.jackson"/>
+			<message key="import.illegal" value="{0}; Use paimon-shade-jackson instead."/>
+		</module>
+		<module name="IllegalImport">
+			<property name="illegalPkgs" value="com.fasterxml.jackson"/>
+			<message key="import.illegal" value="{0}; Use paimon-shade-jackson instead."/>
+		</module>
+		<module name="IllegalImport">
+			<property name="illegalPkgs" value="com.google.common"/>
+			<message key="import.illegal" value="{0}; Use paimon-shade-guava instead."/>
+		</module>
+		<module name="IllegalImport">
+			<property name="illegalPkgs" value="com.github.ben-manes.caffeine"/>
+			<message key="import.illegal" value="{0}; Use paimon-shade-caffeine instead."/>
+		</module>
+		<module name="IllegalImport">
+			<property name="illegalPkgs" value="io.netty"/>
+			<message key="import.illegal" value="{0}; Use paimon-shade-netty instead."/>
+		</module>
+
+		<module name="RedundantModifier">
+			<!-- Checks for redundant modifiers on various symbol definitions.
+			  See: http://checkstyle.sourceforge.net/config_modifier.html#RedundantModifier
+
+			  We exclude METHOD_DEF to allow final methods in final classes to make them more future-proof.
+			-->
+			<property name="tokens"
+					  value="VARIABLE_DEF, ANNOTATION_FIELD_DEF, INTERFACE_DEF, CLASS_DEF, ENUM_DEF"/>
+		</module>
+
+		<!--
+			IllegalImport cannot blacklist classes, and c.g.api.client.util is used for some shaded
+			code and some useful code. So we need to fall back to Regexp.
+		-->
+		<!--<module name="RegexpSinglelineJava">-->
+		<!--<property name="format" value="com\.google\.api\.client\.util\.(ByteStreams|Charsets|Collections2|Joiner|Lists|Maps|Objects|Preconditions|Sets|Strings|Throwables)"/>-->
+		<!--</module>-->
+
+		<!--
+			 Require static importing from Preconditions.
+		-->
+		<module name="RegexpSinglelineJava">
+			<property name="format" value="^import com.google.common.base.Preconditions;$"/>
+			<property name="message" value="Static import functions from Guava Preconditions"/>
+		</module>
+
+		<module name="UnusedImports">
+			<property name="severity" value="error"/>
+			<property name="processJavadoc" value="true"/>
+			<message key="import.unused"
+					 value="Unused import: {0}."/>
+		</module>
+
+		<!--
+
+		JAVADOC CHECKS
+
+		-->
+
+		<!-- Checks for Javadoc comments.                     -->
+		<!-- See http://checkstyle.sf.net/config_javadoc.html -->
+		<module name="JavadocMethod">
+			<property name="scope" value="protected"/>
+			<property name="severity" value="error"/>
+			<property name="allowMissingJavadoc" value="true"/>
+			<property name="allowMissingParamTags" value="true"/>
+			<property name="allowMissingReturnTag" value="true"/>
+			<property name="allowMissingThrowsTags" value="true"/>
+			<property name="allowThrowsTagsForSubclasses" value="true"/>
+			<property name="allowUndeclaredRTE" value="true"/>
+			<!-- This check sometimes failed for with "Unable to get class information for @throws tag" for custom exceptions -->
+			<property name="suppressLoadErrors" value="true"/>
+		</module>
+
+		<!-- Check that paragraph tags are used correctly in Javadoc. -->
+		<module name="JavadocParagraph"/>
+
+		<module name="JavadocType">
+			<property name="scope" value="protected"/>
+			<property name="severity" value="error"/>
+			<property name="allowMissingParamTags" value="true"/>
+		</module>
+
+		<module name="JavadocStyle">
+			<property name="severity" value="error"/>
+			<property name="checkHtml" value="true"/>
+		</module>
+
+		<!--
+
+		NAMING CHECKS
+
+		-->
+
+		<!-- Item 38 - Adhere to generally accepted naming conventions -->
+
+		<module name="PackageName">
+			<!-- Validates identifiers for package names against the
+			  supplied expression. -->
+			<!-- Here the default checkstyle rule restricts package name parts to
+			  seven characters, this is not in line with common practice at Google.
+			-->
+			<property name="format" value="^[a-z]+(\.[a-z][a-z0-9]{1,})*$"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="TypeNameCheck">
+			<!-- Validates static, final fields against the
+			expression "^[A-Z][a-zA-Z0-9]*$". -->
+			<metadata name="altname" value="TypeName"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="ConstantNameCheck">
+			<!-- Validates non-private, static, final fields against the supplied
+			public/package final fields "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$". -->
+			<metadata name="altname" value="ConstantName"/>
+			<property name="applyToPublic" value="true"/>
+			<property name="applyToProtected" value="true"/>
+			<property name="applyToPackage" value="true"/>
+			<property name="applyToPrivate" value="false"/>
+			<property name="format" value="^([A-Z][A-Z0-9]*(_[A-Z0-9]+)*|FLAG_.*)$"/>
+			<message key="name.invalidPattern"
+					 value="Variable ''{0}'' should be in ALL_CAPS (if it is a constant) or be private (otherwise)."/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="StaticVariableNameCheck">
+			<!-- Validates static, non-final fields against the supplied
+			expression "^[a-z][a-zA-Z0-9]*_?$". -->
+			<metadata name="altname" value="StaticVariableName"/>
+			<property name="applyToPublic" value="true"/>
+			<property name="applyToProtected" value="true"/>
+			<property name="applyToPackage" value="true"/>
+			<property name="applyToPrivate" value="true"/>
+			<property name="format" value="^[a-z][a-zA-Z0-9]*_?$"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="MemberNameCheck">
+			<!-- Validates non-static members against the supplied expression. -->
+			<metadata name="altname" value="MemberName"/>
+			<property name="applyToPublic" value="true"/>
+			<property name="applyToProtected" value="true"/>
+			<property name="applyToPackage" value="true"/>
+			<property name="applyToPrivate" value="true"/>
+			<property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="MethodNameCheck">
+			<!-- Validates identifiers for method names. -->
+			<metadata name="altname" value="MethodName"/>
+			<property name="format" value="^[a-z][a-zA-Z0-9]*(_[a-zA-Z0-9]+)*$"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="ParameterName">
+			<!-- Validates identifiers for method parameters against the
+			  expression "^[a-z][a-zA-Z0-9]*$". -->
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="LocalFinalVariableName">
+			<!-- Validates identifiers for local final variables against the
+			  expression "^[a-z][a-zA-Z0-9]*$". -->
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="LocalVariableName">
+			<!-- Validates identifiers for local variables against the
+			  expression "^[a-z][a-zA-Z0-9]*$". -->
+			<property name="severity" value="error"/>
+		</module>
+
+		<!-- Type parameters must be either one of the four blessed letters
+		T, K, V, W, X or else be capital-case terminated with a T,
+		such as MyGenericParameterT -->
+		<!--<module name="ClassTypeParameterName">-->
+		<!--<property name="format" value="^(((T|K|V|W|X)[0-9]*)|([A-Z][a-z][a-zA-Z]*T))$"/>-->
+		<!--<property name="severity" value="error"/>-->
+		<!--</module>-->
+
+		<!--<module name="MethodTypeParameterName">-->
+		<!--<property name="format" value="^(((T|K|V|W|X)[0-9]*)|([A-Z][a-z][a-zA-Z]*T))$"/>-->
+		<!--<property name="severity" value="error"/>-->
+		<!--</module>-->
+
+		<!--<module name="InterfaceTypeParameterName">-->
+		<!--<property name="format" value="^(((T|K|V|W|X)[0-9]*)|([A-Z][a-z][a-zA-Z]*T))$"/>-->
+		<!--<property name="severity" value="error"/>-->
+		<!--</module>-->
+
+		<!--
+
+		LENGTH and CODING CHECKS
+
+		-->
+
+		<!--<module name="LineLength">-->
+		<!--&lt;!&ndash; Checks if a line is too long. &ndash;&gt;-->
+		<!--<property name="max" value="100"/>-->
+		<!--<property name="severity" value="error"/>-->
+
+		<!--&lt;!&ndash;-->
+		<!--The default ignore pattern exempts the following elements:-->
+		<!-- - import statements-->
+		<!-- - long URLs inside comments-->
+		<!--&ndash;&gt;-->
+
+		<!--<property name="ignorePattern"-->
+		<!--value="^(package .*;\s*)|(import .*;\s*)|( *\* .*https?://.*)$"/>-->
+		<!--</module>-->
+
+		<!-- Checks for braces around if and else blocks -->
+		<module name="NeedBraces">
+			<property name="severity" value="error"/>
+			<property name="tokens"
+					  value="LITERAL_IF, LITERAL_ELSE, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO"/>
+		</module>
+
+		<module name="UpperEll">
+			<!-- Checks that long constants are defined with an upper ell.-->
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="FallThrough">
+			<!-- Warn about falling through to the next case statement.  Similar to
+			javac -Xlint:fallthrough, but the check is suppressed if a single-line comment
+			on the last non-blank line preceding the fallen-into case contains 'fall through' (or
+			some other variants that we don't publicized to promote consistency).
+			-->
+			<property name="reliefPattern"
+					  value="fall through|Fall through|fallthru|Fallthru|falls through|Falls through|fallthrough|Fallthrough|No break|NO break|no break|continue on"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<!-- Checks for over-complicated boolean expressions. -->
+		<module name="SimplifyBooleanExpression"/>
+
+		<!-- Detects empty statements (standalone ";" semicolon). -->
+		<module name="EmptyStatement"/>
+
+		<!-- Detect multiple consecutive semicolons (e.g. ";;"). -->
+		<module name="RegexpSinglelineJava">
+			<property name="format" value=";{2,}"/>
+			<property name="message" value="Use one semicolon"/>
+			<property name="ignoreComments" value="true"/>
+		</module>
+
+		<!--
+
+		MODIFIERS CHECKS
+
+		-->
+
+		<module name="ModifierOrder">
+			<!-- Warn if modifier order is inconsistent with JLS3 8.1.1, 8.3.1, and
+				 8.4.3.  The prescribed order is:
+				 public, protected, private, abstract, static, final, transient, volatile,
+				 synchronized, native, strictfp
+			  -->
+			<property name="severity" value="error"/>
+		</module>
+
+
+		<!--
+
+		WHITESPACE CHECKS
+
+		-->
+
+		<module name="EmptyLineSeparator">
+			<!-- Checks for empty line separator between tokens. The only
+				 excluded token is VARIABLE_DEF, allowing class fields to
+				 be declared on consecutive lines.
+			-->
+			<property name="allowMultipleEmptyLines" value="false"/>
+			<property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>
+			<property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF,
+        INTERFACE_DEF, ENUM_DEF, STATIC_INIT, INSTANCE_INIT, METHOD_DEF,
+        CTOR_DEF"/>
+		</module>
+
+		<module name="WhitespaceAround">
+			<!-- Checks that various tokens are surrounded by whitespace.
+				 This includes most binary operators and keywords followed
+				 by regular or curly braces.
+			-->
+			<property name="tokens" value="ASSIGN, BAND, BAND_ASSIGN, BOR,
+        BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN,
+        EQUAL, GE, GT, LAMBDA, LAND, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE,
+        LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN,
+        LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS,
+        MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION,
+        SL, SL_ASSIGN, SR_ASSIGN, STAR, STAR_ASSIGN, TYPE_EXTENSION_AND"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="WhitespaceAfter">
+			<!-- Checks that commas, semicolons and typecasts are followed by
+				 whitespace.
+			-->
+			<property name="tokens" value="COMMA, SEMI, TYPECAST"/>
+		</module>
+
+		<module name="NoWhitespaceAfter">
+			<!-- Checks that there is no whitespace after various unary operators.
+				 Linebreaks are allowed.
+			-->
+			<property name="tokens" value="BNOT, DEC, DOT, INC, LNOT, UNARY_MINUS,
+        UNARY_PLUS"/>
+			<property name="allowLineBreaks" value="true"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="NoWhitespaceBefore">
+			<!-- Checks that there is no whitespace before various unary operators.
+				 Linebreaks are allowed.
+			-->
+			<property name="tokens" value="SEMI, DOT, POST_DEC, POST_INC"/>
+			<property name="allowLineBreaks" value="true"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<!--<module name="OperatorWrap">-->
+		<!--&lt;!&ndash; Checks that operators like + and ? appear at newlines rather than-->
+		<!--at the end of the previous line.-->
+		<!--&ndash;&gt;-->
+		<!--<property name="option" value="NL"/>-->
+		<!--<property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL,-->
+		<!--GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD,-->
+		<!--NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR "/>-->
+		<!--</module>-->
+
+		<module name="OperatorWrap">
+			<!-- Checks that assignment operators are at the end of the line. -->
+			<property name="option" value="eol"/>
+			<property name="tokens" value="ASSIGN"/>
+		</module>
+
+		<module name="ParenPad">
+			<!-- Checks that there is no whitespace before close parens or after
+				 open parens.
+			-->
+			<property name="severity" value="error"/>
+		</module>
+
+	</module>
+</module>
+

--- a/java-based-implementation/paimon-python-java-bridge/tools/maven/suppressions.xml
+++ b/java-based-implementation/paimon-python-java-bridge/tools/maven/suppressions.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!DOCTYPE suppressions PUBLIC
+		"-//Puppy Crawl//DTD Suppressions 1.1//EN"
+		"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+		<suppress files="DataTypes.java" checks="MethodNameCheck"/>
+
+		<!-- target directory is not relevant for checkstyle -->
+		<suppress
+			files="[\\/]target[\\/]"
+			checks=".*"/>
+		<!-- Benchmark CPU metrics collector based on YARN  -->
+		<suppress
+			files="org[\\/]apache[\\/]paimon[\\/]benchmark[\\/]metric[\\/]cpu[\\/].*"
+			checks=".*"/>
+		<!-- Classes copied from AWS -->
+		<suppress
+				files="com[\\/]amazonaws[\\/]services[\\/]s3[\\/]model[\\/]transform[\\/]XmlResponsesSaxParser.java"
+				checks=".*"/>
+</suppressions>


### PR DESCRIPTION
This PR adds a Java module which is a part of Java-base implementation. Main usages:
1. `py4j` will start a JVM, and this module contains the main method.
2. This module have the dependencies of Java objects needed in python.