### PR TITLE
Fix python syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ dependency-reduced-pom.xml
 
 # Python building & testing
 .tox/
+.DS_Store
+__pycache__
 build/
 dev/.conda
 dev/.stage.txt

--- a/java_based_implementation/api_impl.py
+++ b/java_based_implementation/api_impl.py
@@ -22,7 +22,6 @@ from paimon_python_api import (catalog, table, read_builder, table_scan, split, 
                                write_builder, table_write, commit_message, table_commit)
 from pyarrow import RecordBatchReader, RecordBatch
 from typing import List
-from typing_extensions import Self
 
 
 class Catalog(catalog.Catalog):
@@ -37,7 +36,7 @@ class Catalog(catalog.Catalog):
         j_catalog = gateway.jvm.CatalogFactory.createCatalog(j_catalog_context)
         return Catalog(j_catalog)
 
-    def get_table(self, identifier: tuple) -> 'Table':
+    def get_table(self, identifier: str) -> 'Table':
         gateway = get_gateway()
         j_identifier = gateway.jvm.Identifier.fromString(identifier)
         j_table = self._j_catalog.getTable(j_identifier)
@@ -63,11 +62,11 @@ class ReadBuilder(read_builder.ReadBuilder):
     def __init__(self, j_read_builder):
         self._j_read_builder = j_read_builder
 
-    def with_projection(self, projection: List[List[int]]) -> Self:
+    def with_projection(self, projection: List[List[int]]) -> 'ReadBuilder':
         self._j_read_builder.withProjection(projection)
         return self
 
-    def with_limit(self, limit: int) -> Self:
+    def with_limit(self, limit: int) -> 'ReadBuilder':
         self._j_read_builder.withLimit(limit)
         return self
 
@@ -121,7 +120,7 @@ class BatchWriteBuilder(write_builder.BatchWriteBuilder):
     def __init__(self, j_batch_write_builder):
         self._j_batch_write_builder = j_batch_write_builder
 
-    def with_overwrite(self, static_partition: dict) -> Self:
+    def with_overwrite(self, static_partition: dict) -> 'BatchWriteBuilder':
         self._j_batch_write_builder.withOverwrite(static_partition)
         return self
 

--- a/paimon_python_api/catalog.py
+++ b/paimon_python_api/catalog.py
@@ -17,7 +17,7 @@
 #################################################################################
 
 from abc import ABC, abstractmethod
-from table import Table
+from paimon_python_api.table import Table
 
 
 class Catalog(ABC):

--- a/paimon_python_api/read_builder.py
+++ b/paimon_python_api/read_builder.py
@@ -17,21 +17,20 @@
 #################################################################################
 
 from abc import ABC, abstractmethod
-from table_read import TableRead
-from table_scan import TableScan
+from paimon_python_api.table_read import TableRead
+from paimon_python_api.table_scan import TableScan
 from typing import List
-from typing_extensions import Self
 
 
 class ReadBuilder(ABC):
     """An interface for building the TableScan and TableRead."""
 
     @abstractmethod
-    def with_projection(self, projection: List[List[int]]) -> Self:
+    def with_projection(self, projection: List[List[int]]) -> 'ReadBuilder':
         """Push nested projection."""
 
     @abstractmethod
-    def with_limit(self, limit: int) -> Self:
+    def with_limit(self, limit: int) -> 'ReadBuilder':
         """Push row number."""
 
     @abstractmethod

--- a/paimon_python_api/table.py
+++ b/paimon_python_api/table.py
@@ -17,8 +17,8 @@
 #################################################################################
 
 from abc import ABC, abstractmethod
-from read_builder import ReadBuilder
-from write_builder import BatchWriteBuilder
+from paimon_python_api.read_builder import ReadBuilder
+from paimon_python_api.write_builder import BatchWriteBuilder
 
 
 class Table(ABC):

--- a/paimon_python_api/table_commit.py
+++ b/paimon_python_api/table_commit.py
@@ -17,7 +17,7 @@
 #################################################################################
 
 from abc import ABC, abstractmethod
-from commit_message import CommitMessage
+from paimon_python_api.commit_message import CommitMessage
 from typing import List
 
 

--- a/paimon_python_api/table_read.py
+++ b/paimon_python_api/table_read.py
@@ -18,7 +18,7 @@
 
 from abc import ABC, abstractmethod
 from pyarrow import RecordBatchReader
-from split import Split
+from paimon_python_api.split import Split
 
 
 class TableRead(ABC):

--- a/paimon_python_api/table_scan.py
+++ b/paimon_python_api/table_scan.py
@@ -18,8 +18,7 @@
 
 from abc import ABC, abstractmethod
 from typing import List
-
-from split import Split
+from paimon_python_api.split import Split
 
 
 class TableScan(ABC):

--- a/paimon_python_api/table_write.py
+++ b/paimon_python_api/table_write.py
@@ -17,7 +17,7 @@
 #################################################################################
 
 from abc import ABC, abstractmethod
-from commit_message import CommitMessage
+from paimon_python_api.commit_message import CommitMessage
 from pyarrow import RecordBatch
 from typing import List
 

--- a/paimon_python_api/write_builder.py
+++ b/paimon_python_api/write_builder.py
@@ -17,16 +17,15 @@
 #################################################################################
 
 from abc import ABC, abstractmethod
-from table_commit import BatchTableCommit
-from table_write import BatchTableWrite
-from typing_extensions import Self
+from paimon_python_api.table_commit import BatchTableCommit
+from paimon_python_api.table_write import BatchTableWrite
 
 
 class BatchWriteBuilder(ABC):
     """An interface for building the TableScan and TableRead."""
 
     @abstractmethod
-    def with_overwrite(self, static_partition: dict) -> Self:
+    def with_overwrite(self, static_partition: dict) -> 'BatchWriteBuilder':
         """
         Overwrite writing, same as the 'INSERT OVERWRITE T PARTITION (...)' semantics of SQL.
         If you pass an empty dict, it means OVERWRITE whole table.


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
1. 'Self' keyword is not backward compatible
2. API module import should add qualifier to avoid 'module not found' error

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
