### PR TITLE
Fix that field nullability affects write

### DIFF
--- a/paimon_python_java/paimon-python-java-bridge/src/main/java/org/apache/paimon/python/BytesWriter.java
+++ b/paimon_python_java/paimon-python-java-bridge/src/main/java/org/apache/paimon/python/BytesWriter.java
@@ -87,7 +87,7 @@ public class BytesWriter {
         for (int i = 0; i < expectedFields.size(); i++) {
             Field expectedField = expectedFields.get(i);
             Field actualField = actualFields.get(i);
-            if (!checkField(expectedField, actualField)
+            if (!checkFieldIgnoreNullability(expectedField, actualField)
                     || !checkSchema(expectedField.getChildren(), actualField.getChildren())) {
                 return false;
             }
@@ -96,7 +96,7 @@ public class BytesWriter {
         return true;
     }
 
-    private boolean checkField(Field expected, Field actual) {
+    private boolean checkFieldIgnoreNullability(Field expected, Field actual) {
         return Objects.equals(expected.getName(), actual.getName())
                 && Objects.equals(expected.getType(), actual.getType());
     }

--- a/paimon_python_java/paimon-python-java-bridge/src/main/java/org/apache/paimon/python/BytesWriter.java
+++ b/paimon_python_java/paimon-python-java-bridge/src/main/java/org/apache/paimon/python/BytesWriter.java
@@ -89,7 +89,8 @@ public class BytesWriter {
             Field actualField = actualFields.get(i);
             // ArrowType doesn't have nullability (similar to DataTypeRoot)
             if (!actualField.getType().equals(expectedField.getType())
-                    || !checkSchema(expectedField.getChildren(), actualField.getChildren())) {
+                    || !checkTypesIgnoreNullability(
+                            expectedField.getChildren(), actualField.getChildren())) {
                 return false;
             }
         }

--- a/paimon_python_java/paimon-python-java-bridge/src/main/java/org/apache/paimon/python/BytesWriter.java
+++ b/paimon_python_java/paimon-python-java-bridge/src/main/java/org/apache/paimon/python/BytesWriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.paimon.python;
 
+import org.apache.paimon.arrow.ArrowUtils;
 import org.apache.paimon.arrow.reader.ArrowBatchReader;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.table.sink.TableWrite;
@@ -27,8 +28,12 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowStreamReader;
+import org.apache.arrow.vector.types.pojo.Field;
 
 import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /** Write Arrow bytes to Paimon. */
 public class BytesWriter {
@@ -36,17 +41,30 @@ public class BytesWriter {
     private final TableWrite tableWrite;
     private final ArrowBatchReader arrowBatchReader;
     private final BufferAllocator allocator;
+    private final List<Field> arrowFields;
 
     public BytesWriter(TableWrite tableWrite, RowType rowType) {
         this.tableWrite = tableWrite;
         this.arrowBatchReader = new ArrowBatchReader(rowType);
         this.allocator = new RootAllocator();
+        arrowFields =
+                rowType.getFields().stream()
+                        .map(f -> ArrowUtils.toArrowField(f.name(), f.type()))
+                        .collect(Collectors.toList());
     }
 
-    public void write(byte[] bytes) throws Exception {
+    public void write(byte[] bytes, boolean needCheckSchema) throws Exception {
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ArrowStreamReader arrowStreamReader = new ArrowStreamReader(bais, allocator);
         VectorSchemaRoot vsr = arrowStreamReader.getVectorSchemaRoot();
+        if (needCheckSchema && !checkSchema(arrowFields, vsr.getSchema().getFields())) {
+            throw new RuntimeException(
+                    String.format(
+                            "Input schema isn't consistent with table schema.\n"
+                                    + "\tTable schema is: %s\n"
+                                    + "\tInput schema is: %s",
+                            arrowFields, vsr.getSchema().getFields()));
+        }
 
         while (arrowStreamReader.loadNextBatch()) {
             Iterable<InternalRow> rows = arrowBatchReader.readBatch(vsr);
@@ -59,5 +77,27 @@ public class BytesWriter {
 
     public void close() {
         allocator.close();
+    }
+
+    private boolean checkSchema(List<Field> expectedFields, List<Field> actualFields) {
+        if (expectedFields.size() != actualFields.size()) {
+            return false;
+        }
+
+        for (int i = 0; i < expectedFields.size(); i++) {
+            Field expectedField = expectedFields.get(i);
+            Field actualField = actualFields.get(i);
+            if (!checkField(expectedField, actualField)
+                    || !checkSchema(expectedField.getChildren(), actualField.getChildren())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private boolean checkField(Field expected, Field actual) {
+        return Objects.equals(expected.getName(), actual.getName())
+                && Objects.equals(expected.getType(), actual.getType());
     }
 }

--- a/paimon_python_java/pypaimon.py
+++ b/paimon_python_java/pypaimon.py
@@ -219,21 +219,21 @@ class BatchTableWrite(table_write.BatchTableWrite):
     def write_arrow(self, table):
         for record_batch in table.to_reader():
             # TODO: can we use a reusable stream in #_write_arrow_batch ?
-            self._write_arrow_batch(record_batch, True)
+            self._write_arrow_batch(record_batch)
 
     def write_arrow_batch(self, record_batch):
-        self._write_arrow_batch(record_batch, True)
+        self._write_arrow_batch(record_batch)
 
     def write_pandas(self, dataframe: pd.DataFrame):
         record_batch = pa.RecordBatch.from_pandas(dataframe, schema=self._arrow_schema)
-        self._write_arrow_batch(record_batch, False)
+        self._write_arrow_batch(record_batch)
 
-    def _write_arrow_batch(self, record_batch, check_schema):
+    def _write_arrow_batch(self, record_batch):
         stream = pa.BufferOutputStream()
         with pa.RecordBatchStreamWriter(stream, record_batch.schema) as writer:
             writer.write(record_batch)
         arrow_bytes = stream.getvalue().to_pybytes()
-        self._j_bytes_writer.write(arrow_bytes, check_schema)
+        self._j_bytes_writer.write(arrow_bytes)
 
     def prepare_commit(self) -> List['CommitMessage']:
         j_commit_messages = self._j_batch_table_write.prepareCommit()

--- a/paimon_python_java/pypaimon.py
+++ b/paimon_python_java/pypaimon.py
@@ -218,23 +218,22 @@ class BatchTableWrite(table_write.BatchTableWrite):
 
     def write_arrow(self, table):
         for record_batch in table.to_reader():
-            # TODO: can we use a reusable stream?
-            stream = pa.BufferOutputStream()
-            with pa.RecordBatchStreamWriter(stream, self._arrow_schema) as writer:
-                writer.write(record_batch)
-            arrow_bytes = stream.getvalue().to_pybytes()
-            self._j_bytes_writer.write(arrow_bytes)
+            # TODO: can we use a reusable stream in #_write_arrow_batch ?
+            self._write_arrow_batch(record_batch, True)
 
     def write_arrow_batch(self, record_batch):
-        stream = pa.BufferOutputStream()
-        with pa.RecordBatchStreamWriter(stream, self._arrow_schema) as writer:
-            writer.write(record_batch)
-        arrow_bytes = stream.getvalue().to_pybytes()
-        self._j_bytes_writer.write(arrow_bytes)
+        self._write_arrow_batch(record_batch, True)
 
     def write_pandas(self, dataframe: pd.DataFrame):
         record_batch = pa.RecordBatch.from_pandas(dataframe, schema=self._arrow_schema)
-        self.write_arrow_batch(record_batch)
+        self._write_arrow_batch(record_batch, False)
+
+    def _write_arrow_batch(self, record_batch, check_schema):
+        stream = pa.BufferOutputStream()
+        with pa.RecordBatchStreamWriter(stream, record_batch.schema) as writer:
+            writer.write(record_batch)
+        arrow_bytes = stream.getvalue().to_pybytes()
+        self._j_bytes_writer.write(arrow_bytes, check_schema)
 
     def prepare_commit(self) -> List['CommitMessage']:
         j_commit_messages = self._j_batch_table_write.prepareCommit()


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
The case is:
1. create a primary key table, the column `pk` is non-null from Paimon;
2. schema of arrow data might not be defined `pk not null` strictly , so  `with pa.RecordBatchStreamWriter(stream, self._arrow_schema) as writer` will throw error.

Fix: `pa.RecordBatchStreamWriter` use data's schema, and let java codes to check field (ignore nullability)
 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
