### PR TITLE
[release-tool] Minor fix create_binary_release.sh

### DIFF
--- a/tools/releasing/create_binary_release.sh
+++ b/tools/releasing/create_binary_release.sh
@@ -61,9 +61,12 @@ source dev/.conda/bin/activate
 dev/build-wheels.sh
 
 WHEEL_FILE_NAME="paimon_python-${RELEASE_VERSION}-py3-none-any.whl"
-WHEEL_FILE="${RELEASE_DIR}/${WHEEL_FILE_NAME}"
-cp "dist/${WHEEL_FILE_NAME}" ${WHEEL_FILE}
+cp "dist/${WHEEL_FILE_NAME}" "${RELEASE_DIR}/${WHEEL_FILE_NAME}"
+
+cd ${RELEASE_DIR}
 
 # Sign sha the wheel package
-gpg --armor --detach-sig ${WHEEL_FILE}
-$SHASUM ${WHEEL_FILE} > "${WHEEL_FILE}.sha512"
+gpg --armor --detach-sig ${WHEEL_FILE_NAME}
+$SHASUM ${WHEEL_FILE_NAME} > "${WHEEL_FILE_NAME}.sha512"
+
+cd ${CURR_DIR}


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Currently, the sha will be like:
```
xxx  /Users/yuzelin/PycharmProjects/paimon-python/tools/releasing/../..//release/binary/paimon_python-0.1.1-py3-none-any.whl
```

This PR makes it:
```
xxx paimon_python-0.1.1-py3-none-any.whl
```

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
