### PR TITLE
Refactor ReadBuilder#with_projection to accept field names for better using

### DIFF
--- a/paimon_python_api/read_builder.py
+++ b/paimon_python_api/read_builder.py
@@ -32,7 +32,7 @@ class ReadBuilder(ABC):
         """
 
     @abstractmethod
-    def with_projection(self, projection: List[List[int]]) -> 'ReadBuilder':
+    def with_projection(self, projection: List[str]) -> 'ReadBuilder':
         """Push nested projection."""
 
     @abstractmethod

--- a/paimon_python_java/util/java_utils.py
+++ b/paimon_python_java/util/java_utils.py
@@ -91,3 +91,12 @@ def _to_j_type(name, pa_type):
         return jvm.DataTypes.STRING()
     else:
         raise ValueError(f'Found unsupported data type {str(pa_type)} for field {name}.')
+
+
+def to_arrow_schema(j_row_type):
+    # init arrow schema
+    schema_bytes = get_gateway().jvm.SchemaUtil.getArrowSchema(j_row_type)
+    schema_reader = pa.RecordBatchStreamReader(pa.BufferReader(schema_bytes))
+    arrow_schema = schema_reader.schema
+    schema_reader.close()
+    return arrow_schema


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
It is not easy to use `int[]` for projection.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
