### PR TITLE
[tool] Convenient shell tool for building source distribution package

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ We provide script to check codes.
 ./dev/lint-python.sh -h # run this to see more usages         
 ```
 
+## Build
+
+We provide a script to build source distribution package.
+
+```shell
+./dev/build-source-distribution-package.sh
+```
+
+The package is under `dist/`.
+
 # Usage
 
 See Apache Paimon Python API [Doc](https://paimon.apache.org/docs/master/program-api/python-api/).

--- a/dev/build-source-distribution-package.sh
+++ b/dev/build-source-distribution-package.sh
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+CURR_DIR=`pwd`
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+PROJECT_ROOT="${BASE_DIR}/../"
+
+# prepare bridge jar
+
+DEPS_DIR=${PROJECT_ROOT}/deps/jars
+rm -rf ${DEPS_DIR}
+mkdir -p ${DEPS_DIR}
+
+cd ${PROJECT_ROOT}/paimon-python-java-bridge
+
+# get bridge jar version
+JAR_VERSION=$(sed -n 's/.*<version>\(.*\)<\/version>.*/\1/p' pom.xml | head -n 1)
+
+mvn clean install -DskipTests
+cp "target/paimon-python-java-bridge-${JAR_VERSION}.jar" ${DEPS_DIR}
+
+cd ${CURR_DIR}
+
+# build source distribution package
+
+python setup.py sdist
+
+rm -rf ${DEPS_DIR}
+cd ${CURR_DIR}


### PR DESCRIPTION
### Purpose

This is different from the github build action: the action builds a release package and signs it; this shell only builds package and doesn't care if it is under developing.

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
