### PR TITLE
Add license checker

### DIFF
--- a/.github/workflows/check-licensing.yml
+++ b/.github/workflows/check-licensing.yml
@@ -1,0 +1,38 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+name: Check licensing
+
+on: [push, pull_request]
+
+jobs:
+  rat-check:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: 8
+          distribution: 'adopt'
+
+      - name: Check licensing
+        run: ./dev/check-licensing.sh

--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -1,0 +1,21 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+paimon-python-java-bridge/*
+.gitignore
+rat-results.txt

--- a/dev/check-licensing.sh
+++ b/dev/check-licensing.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+download_rat_jar () {
+    URL="https://repo.maven.apache.org/maven2/org/apache/rat/apache-rat/${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar"
+    JAR="$rat_jar"
+
+    # Download rat launch jar
+    echo "Attempting to fetch rat"
+    wget --quiet ${URL} -O "$JAR"
+}
+
+CURR_DIR=`pwd`
+SOURCE_PACKAGE=${SOURCE_PACKAGE}
+
+export RAT_VERSION=0.15
+export rat_jar=rat/apache-rat-${RAT_VERSION}.jar
+
+if [ -z "${SOURCE_PACKAGE}" ]; then
+    BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+    PROJECT_ROOT="${BASE_DIR}/../"
+    cd ${PROJECT_ROOT}
+
+    # Sanity check to ensure that resolved paths are valid; a LICENSE file should always exist in project root
+    if [ ! -f ${PROJECT_ROOT}/LICENSE ]; then
+        echo "Project root path ${PROJECT_ROOT} is not valid; script may be in the wrong directory."
+        exit 1
+    fi
+
+	  RUN_RAT="java -jar ${rat_jar} -E ${PROJECT_ROOT}/dev/.rat-excludes -d ${PROJECT_ROOT}"
+else
+    EXTENSION='.tar.gz'
+    # get unzipped directory
+    PACKAGE_DIR="${SOURCE_PACKAGE:0:$((${#SOURCE_PACKAGE} - ${#EXTENSION}))}"
+    tar -xf ${SOURCE_PACKAGE}
+
+    RUN_RAT="java -jar ${rat_jar} -d ${PACKAGE_DIR}"
+fi
+
+mkdir -p rat
+download_rat_jar
+
+$RUN_RAT > rat/rat-results.txt
+
+if [ $? -ne 0 ]; then
+    echo "RAT exited abnormally"
+    exit 1
+fi
+
+ERRORS="$(cat rat/rat-results.txt | grep -e "??")"
+
+if [[ -n "${ERRORS}" ]]; then
+    echo "Could not find Apache license headers in the following files:"
+    echo ${ERRORS}
+    exit 1
+else
+    echo -e "RAT checks passed."
+fi

--- a/dev/check-licensing.sh
+++ b/dev/check-licensing.sh
@@ -50,7 +50,7 @@ else
     PACKAGE_DIR="${SOURCE_PACKAGE:0:$((${#SOURCE_PACKAGE} - ${#EXTENSION}))}"
     tar -xf ${SOURCE_PACKAGE}
 
-    RUN_RAT="java -jar ${rat_jar} -d ${PACKAGE_DIR}"
+    RUN_RAT="java -jar ${rat_jar} -e PKG-INFO -e setup.cfg -e pypaimon.egg-info/* -d ${PACKAGE_DIR}"
 fi
 
 mkdir -p rat
@@ -64,6 +64,12 @@ if [ $? -ne 0 ]; then
 fi
 
 ERRORS="$(cat rat/rat-results.txt | grep -e "??")"
+
+# clean
+rm -rf rat
+if [ -d "$PACKAGE_DIR" ]; then
+    rm -rf $PACKAGE_DIR
+fi
 
 if [[ -n "${ERRORS}" ]]; then
     echo "Could not find Apache license headers in the following files:"


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Tool to check the license of files.
1. It will be called by Github workflow to check project files (except java module)
2. It can be called manually to verify the package files (except files generated by python package tool):
`SOURCE_PACKAGE=pypaimon-0.2.0.tar.gz ./check-licensing.sh`

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
