### PR TITLE
#38 Expose More Metadata in Object APIs

### DIFF
--- a/pypaimon/api/read_builder.py
+++ b/pypaimon/api/read_builder.py
@@ -20,6 +20,8 @@ from abc import ABC, abstractmethod
 from pypaimon.api import TableRead, TableScan, Predicate, PredicateBuilder
 from typing import List
 
+from pypaimon.api.row_type import RowType
+
 
 class ReadBuilder(ABC):
     """An interface for building the TableScan and TableRead."""
@@ -50,3 +52,10 @@ class ReadBuilder(ABC):
     @abstractmethod
     def new_predicate_builder(self) -> PredicateBuilder:
         """Create a builder for Predicate."""
+
+    @abstractmethod
+    def read_type(self) -> RowType:
+        """
+        Return the row type of the builder. If there is a projection inside
+        the builder, the row type will only contain the selected fields.
+        """

--- a/pypaimon/api/row_type.py
+++ b/pypaimon/api/row_type.py
@@ -16,20 +16,14 @@
 # limitations under the License.
 #################################################################################
 
+import pyarrow as pa
+
 from abc import ABC, abstractmethod
 
-from typing import Iterator
 
-
-class Split(ABC):
-    """An input split for reading. The most important subclass is DataSplit."""
+class RowType(ABC):
+    """Data type of a sequence of fields."""
 
     @abstractmethod
-    def row_count(self) -> int:
-        """Return the total row count of the split."""
-
-    def file_size(self) -> int:
-        """Return the total file size of the split."""
-
-    def file_paths(self) -> Iterator[str]:
-        """Return the paths of all raw files in the split."""
+    def as_arrow(self) -> "pa.Schema":
+        """Return the row type as an Arrow schema."""

--- a/pypaimon/py4j/tests/test_object_metadata.py
+++ b/pypaimon/py4j/tests/test_object_metadata.py
@@ -1,0 +1,73 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import os
+import pyarrow as pa
+
+from pypaimon import Schema
+from pypaimon.py4j.tests import PypaimonTestBase
+
+
+class ObjectInfoTest(PypaimonTestBase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.simple_pa_schema = pa.schema([
+            ('f0', pa.int32()),
+            ('f1', pa.string())
+        ])
+
+    def test_read_type_metadata(self):
+        schema = Schema(self.simple_pa_schema)
+        self.catalog.create_table('default.test_read_type_metadata', schema, False)
+        table = self.catalog.get_table('default.test_read_type_metadata')
+
+        read_builder = table.new_read_builder()
+        read_builder.with_projection(['f1'])
+        pa_schema = read_builder.read_type().as_arrow()
+
+        self.assertEqual(len(pa_schema.names), 1)
+        self.assertEqual(pa_schema.names[0], 'f1')
+
+    def test_split_metadata(self):
+        schema = Schema(self.simple_pa_schema)
+        self.catalog.create_table('default.test_split_metadata', schema, False)
+        table = self.catalog.get_table('default.test_split_metadata')
+
+        write_builder = table.new_batch_write_builder()
+        table_write = write_builder.new_write()
+        table_commit = write_builder.new_commit()
+        data = {
+            'f0': [1, 2, 3, 4, 5],
+            'f1': ['a', 'b', 'c', 'd', 'e'],
+        }
+        pa_table = pa.Table.from_pydict(data, schema=self.simple_pa_schema)
+        table_write.write_arrow(pa_table)
+        table_commit.commit(table_write.prepare_commit())
+        table_write.close()
+        table_commit.close()
+        read_builder = table.new_read_builder()
+        table_scan = read_builder.new_scan()
+        splits = table_scan.plan().splits()
+
+        self.assertEqual(len(splits), 1)
+        self.assertEqual(len(splits[0].file_paths()), 1)
+        self.assertEqual(splits[0].row_count(), 5)
+        self.assertTrue(splits[0].file_paths()[0].endswith('.parquet'))
+        self.assertEqual(splits[0].file_size(), os.path.getsize(splits[0].file_paths()[0]))


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #38

<!-- What is the purpose of the change -->
Expose More Metadata in Object APIs, for the benefice for optimizing read/write strategies.

### Tests

<!-- List UT and IT cases to verify this change -->
- test_read_type_metadata
- test_split_metadata

### API and Format

<!-- Does this change affect API or storage format -->
Yes.
- add new object `RowType` with method `as_arrow`.
- add new methods `row_count`, `file_size`, `file_paths` to the object `Split`.
- and new method `read_type` to the object `ReadBuilder`, which following the design of java paimon.

### Documentation

<!-- Does this change introduce a new feature -->
